### PR TITLE
ability to pass props into Paper and have them passed into the three script.

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -43,7 +43,7 @@ export function Paper<T extends { [key: string]: any }>({ script, style, onExit,
         prevProps.current[key] = props[key];
       });
       if (Object.keys(changesObj).length) {
-        scriptReturn.onChange(changesObj as T);
+        scriptReturn.onChange?.(changesObj as T);
       }
     }
   }, [scriptReturn, props]);


### PR DESCRIPTION
Added a way for any props passed into the `<Paper>` component get passed into the three script. The initial state of the props gets passed into the main script as a second arg, but also When those props change, the `onChange` property of the three script gets called with an object where the key is the name of any props that changed and the value is the new value for each prop.

it's still best to memoize any complex props being passed in, lest your onChange get called every react rerender, but it now it allows for some reactive control without being too overbearing.

I also added className to the canvas props because I use styled components :P